### PR TITLE
remove ‘case study’ and ‘white paper’ from sidebar item titles

### DIFF
--- a/_downloads/five-things-every-retailer-should-know-about-personalisation-whitepaper.markdown
+++ b/_downloads/five-things-every-retailer-should-know-about-personalisation-whitepaper.markdown
@@ -1,5 +1,5 @@
 ---
-title: Five Things Every Retailer Should Know About Personalisation Whitepaper
+title: Five Things Every Retailer Should Know About Personalisation
 date: 2017-08-22 13:19:00 Z
 resource: Whitepaper
 form:

--- a/_downloads/how-dressipi-can-help-retailers-transform-their-biggest-asset-whitepaper.markdown
+++ b/_downloads/how-dressipi-can-help-retailers-transform-their-biggest-asset-whitepaper.markdown
@@ -1,5 +1,5 @@
 ---
-title: How Dressipi Can Help Retailers Transform Their Biggest Asset Whitepaper
+title: How Dressipi Can Help Retailers Transform Their Biggest Asset 
 date: 2017-05-12 04:38:00 Z
 resource: Whitepaper
 form:

--- a/_downloads/shop-direct-case-study.markdown
+++ b/_downloads/shop-direct-case-study.markdown
@@ -1,5 +1,5 @@
 ---
-title: Shop Direct Case Study
+title: Shop Direct
 date: 2017-05-10 11:20:00 Z
 resource: Case Study
 form:

--- a/_posts/2017-10-23-style-advice-something-for-the-weekend.markdown
+++ b/_posts/2017-10-23-style-advice-something-for-the-weekend.markdown
@@ -8,7 +8,7 @@ tags:
 - style tips
 image: "/uploads/something-for-the-weekend.jpg"
 author: Selina Mills
-download: Shop Direct Case Study
+download: Shop Direct
 layout: post
 ---
 

--- a/customer-first-personalisation.markdown
+++ b/customer-first-personalisation.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_sdg_withlogo.jpg"
 is-landing-page: true
-downloads: Shop Direct Case Study
+downloads: Shop Direct
 ---
 
 ## Download our free whitepaper ‘Five Things Every Retailer Should Know About Personalisation’ to learn:

--- a/fashion-personalisation-v1.markdown
+++ b/fashion-personalisation-v1.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_sdg_withlogo.jpg"
 is-landing-page: true
-downloads: Shop Direct Case Study
+downloads: Shop Direct
 description: Fashion Personalisation v1
 ---
 

--- a/fashion-personalisation-v2.markdown
+++ b/fashion-personalisation-v2.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_sdg_withlogo.jpg"
 is-landing-page: true
-downloads: Shop Direct Case Study
+downloads: Shop Direct
 ---
 
 ## Download our free case study ‘Personalising the Entire Customer Experience for Shop Direct’ to learn:

--- a/fashion-specific-personalisation-v2.markdown
+++ b/fashion-specific-personalisation-v2.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_sdg_withlogo.jpg"
 is-landing-page: true
-downloads: Shop Direct Case Study
+downloads: Shop Direct
 ---
 
 ## Download our free case study ‘Personalising the Entire Customer Experience for Shop Direct’ to learn:

--- a/how-it-works.markdown
+++ b/how-it-works.markdown
@@ -54,7 +54,7 @@ sections:
 - title: Case Study
   handle: cases
   downloads:
-  - Shop Direct Case Study
+  - Shop Direct
 layout: how-it-works
 ---
 

--- a/how-to-deliver-true-personalisation.markdown
+++ b/how-to-deliver-true-personalisation.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_five_things_whitepaper.jpg"
 is-landing-page: true
-downloads: Five Things Every Retailer Should Know About Personalisation Whitepaper
+downloads: Five Things Every Retailer Should Know About Personalisation
 ---
 
 ## Download our free whitepaper ‘Five Things Every Retailer Should Know About Personalisation’ to learn:

--- a/how-to-improve-customer-experience-online.markdown
+++ b/how-to-improve-customer-experience-online.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_five_things_whitepaper.jpg"
 is-landing-page: true
-downloads: Five Things Every Retailer Should Know About Personalisation Whitepaper
+downloads: Five Things Every Retailer Should Know About Personalisation
 description: How to Improve Customer Experience Online
 ---
 

--- a/omnichannel-personalisation.markdown
+++ b/omnichannel-personalisation.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_biggest_asset_whitepaper.jpg"
 is-landing-page: true
-downloads: Five Things Every Retailer Should Know About Personalisation Whitepaper
+downloads: Five Things Every Retailer Should Know About Personalisation
 description: Dressipi is the global leader in Omnichannel Personalisation. We give
   each customer their own tailored shopping experience across all channels and devices
   online and instore. This enables retailers to match customers with products and

--- a/one-to-one-personalisation.markdown
+++ b/one-to-one-personalisation.markdown
@@ -12,7 +12,7 @@ header:
     copy: Download Case Study
     url: "#download"
 is-landing-page: true
-downloads: Shop Direct Case Study
+downloads: Shop Direct
 ---
 
 ## Download our free case study ‘Personalising the Entire Customer Experience for Shop Direct’ to learn:

--- a/partners.markdown
+++ b/partners.markdown
@@ -36,7 +36,7 @@ sections:
   - title: The Results
     image: "/uploads/icon__results.svg"
   downloads:
-  - Shop Direct Case Study
+  - Shop Direct
 - title: Explore More
   body: Try it for yourself by clicking the links below, or visit our [How it Works](/how-it-works)
     page to find out more about how to integrate this technology into your own site.
@@ -53,4 +53,3 @@ sections:
   - Autograph
 layout: partners
 ---
-

--- a/retail-personalisation-v2.markdown
+++ b/retail-personalisation-v2.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_sdg_withlogo.jpg"
 is-landing-page: true
-downloads: Shop Direct Case Study
+downloads: Shop Direct
 ---
 
 ## Download our free case study ‘Personalising the Entire Customer Experience for Shop Direct’ to learn:

--- a/solutions/customer-experience.markdown
+++ b/solutions/customer-experience.markdown
@@ -91,7 +91,7 @@ sections:
 - title: Case Study
   handle: cases
   downloads:
-  - Shop Direct Case Study
+  - Shop Direct
 layout: product
 ---
 

--- a/solutions/data-insight.markdown
+++ b/solutions/data-insight.markdown
@@ -64,7 +64,7 @@ sections:
 - title: Case Study
   handle: cases
   downloads:
-  - Shop Direct Case Study
+  - Shop Direct
 layout: product
 ---
 

--- a/solutions/innovation.markdown
+++ b/solutions/innovation.markdown
@@ -78,7 +78,7 @@ sections:
 - title: Case Study
   handle: cases
   downloads:
-  - Shop Direct Case Study
+  - Shop Direct
 layout: product
 ---
 

--- a/true-personalisation.markdown
+++ b/true-personalisation.markdown
@@ -13,7 +13,7 @@ header:
     url: "#download"
   hero-image: "/uploads/banner_sdg_withlogo.jpg"
 is-landing-page: true
-downloads: Shop Direct Case Study
+downloads: Shop Direct
 ---
 
 ## Download our free case study ‘Personalising the Entire Customer Experience for Shop Direct’ to learn:


### PR DESCRIPTION
remove ‘case study’ and ‘white paper’ from sidebar item titles